### PR TITLE
1000件以上の小テストがあるときにJavascriptエラーが発生するため、必要最低限の取得に修正

### DIFF
--- a/Controller/QuizzesController.php
+++ b/Controller/QuizzesController.php
@@ -186,6 +186,9 @@ class QuizzesController extends QuizzesAppController {
 		// 過去データ 取り出し
 		$pastQuizzes = $this->Quiz->find('all',
 			array(
+				'fields' => array(
+					'id', 'title', 'status', 'answer_timing', 'answer_start_period', 'answer_end_period',
+				),
 				'conditions' => $this->Quiz->getCondition(),
 				'offset' => 0,
 				'limit' => 1000,


### PR DESCRIPTION
1000件以上の小テストがあるときにJavascriptエラーが発生する。

![default](https://cloud.githubusercontent.com/assets/4422735/16890815/26001f82-4b2d-11e6-8923-709a449282aa.PNG)

おそらく、この辺でエラーになっています。
https://github.com/NetCommons3/Quizzes/blob/master/View/Quizzes/add.ctp#L20-L22

そのため、取得するデータを必要最低限に修正しました。