### PR TITLE
pluginKeyの直書き指定不要になった - blockSetting共通化対応

### DIFF
--- a/Model/QuizSetting.php
+++ b/Model/QuizSetting.php
@@ -34,7 +34,6 @@ class QuizSetting extends BlockBaseModel {
 		'Blocks.BlockRolePermission',
 		'Blocks.BlockSetting' => array(
 			BlockSettingBehavior::FIELD_USE_WORKFLOW,
-			BlockSettingBehavior::SETTING_PLUGIN_KEY => 'quizzes',
 		),
 	);
 


### PR DESCRIPTION
トラビスOK後、マージお願いします。