### PR TITLE
refactor: 不要な処理を削除

### DIFF
--- a/View/Elements/QuizEdit/EditQuestion/hidden_page_info_set.ctp
+++ b/View/Elements/QuizEdit/EditQuestion/hidden_page_info_set.ctp
@@ -15,5 +15,3 @@
 	array('ng-value' => 'page.pageSequence'));
 	echo $this->NetCommonsForm->hidden('QuizPage.{{pageIndex}}.key',
 	array('ng-value' => 'page.key'));
-	$this->NetCommonsForm->hidden('QuizPage.{{pageIndex}}.page_title',
-	array('ng-value' => 'page.pageTitle'));


### PR DESCRIPTION
※初期設計では、ページ名を自由に変更できる設計だったが、その仕様は無くなった(？)ため不要になった。